### PR TITLE
Custom colors + gradients

### DIFF
--- a/Sandbox/Program.cs
+++ b/Sandbox/Program.cs
@@ -14,6 +14,8 @@ using Levrum.Utils.Geography;
 
 using Levrum.Utils.Osm;
 using Levrum.Utils.Geometry;
+using System.Drawing;
+using System.Diagnostics;
 
 namespace Sandbox
 {
@@ -83,6 +85,103 @@ namespace Sandbox.DefaultCommands
             catch
             {
                 return "What the quack? You didn't quack right. Enter 'quack latitude longitude unit(optional)'. QUACK!";
+            }
+        }
+
+        public static string gradtests(List<string> args)
+        {
+            try
+            {
+                Stopwatch sw = new Stopwatch();
+                sw.Start();
+                int failures = 0;
+                string result = "";
+                Levrum.Utils.Colors.Gradients cg = new Levrum.Utils.Colors.Gradients();
+                Random r = new Random();
+                List<Image> gradientList = new List<Image>();
+                for (int i = 0; i < 5; i++)
+                {
+                    List<Color> gradient = cg.CreateTwoColorGradient(Color.FromArgb(r.Next(0, 255), r.Next(0, 255), r.Next(0, 255)),
+                        Color.FromArgb(r.Next(0, 255), r.Next(0, 255), r.Next(0, 255)), 256);
+                    gradientList.Add(cg.CreateGradientImage(gradient, 256, 200));
+
+                    List<Color> nColors = new List<Color>();
+                    int n = r.Next(3, 10);
+                    for (int j = 0; j < n; j++)
+                    {
+                        nColors.Add(Color.FromArgb(r.Next(0, 255), r.Next(0, 255), r.Next(0, 255)));
+                    }
+                    gradientList.Add(cg.CreateGradientImage(cg.CreateNColorGradient(nColors, (255 * (n-1)) + 2)));
+                }
+
+                if (!cg.SaveGradientList(gradientList))
+                {
+                    result = "GradientListSaveFailed";
+                    failures--;
+                }
+
+                List<Color> test2 = cg.CreateThreeColorGradient(Color.Red, Color.White, Color.Blue, (256 * 2));
+                if(!cg.SaveGradient(test2, "Murica"))
+                {
+                    result += ".   Three color gradient save failed";
+                }
+
+                List<Color> b = new List<Color>
+                {
+                    Color.FromArgb(255,255,255,255),
+                    Color.FromArgb(255,0,0,0),
+                    Color.FromArgb(255,255,255,255),
+                    Color.FromArgb(255,0,0,0),
+                    Color.FromArgb(255,255,255,255),
+                    Color.FromArgb(255,0,0,0),
+                };
+
+                List<Color> finalTest = cg.CreateNColorGradient(b, (255 * 5) + 2);
+                if(!cg.SaveGradient(cg.CreateGradientImage(finalTest), "Zebra.png"))
+                {
+                    result += ".   N color gradient save failed";
+                    failures++;
+                }
+
+                int index = 0;
+                List<Color> reloaded = cg.ExtractGradientFromImage(cg.LoadGradientImage("Zebra"));
+                foreach (Color c in reloaded)
+                {
+                    if(finalTest[index].Name != c.Name)
+                    {
+                        result += ".   N color reload failed";
+                        failures++;
+                        break;
+                    }
+                    index++;
+                }
+                index = 0;
+                reloaded = cg.ExtractGradientFromImage(cg.LoadGradientImage("Zebra.png"));
+                foreach (Color c in reloaded)
+                {
+                    if (finalTest[index].Name != c.Name)
+                    {
+                        result += ".   N color reload 2 failed";
+                        failures++;
+                        break;
+                    }
+                    index++;
+                }
+                List <Image> imageList = cg.LoadAllGradientImages();
+
+                if(imageList.Count == 0)
+                {
+                    result += ".   All image load failed.";
+                    failures++;
+                }
+
+                sw.Stop();
+                result += " " + failures + " tests failed. Ran in " + sw.ElapsedMilliseconds + " ms.   Successfully saved files are in AppData\\Levrum\\CustomColors\\Gradients";
+                return result;
+            }
+            catch
+            {
+                return "Tests failed";
             }
         }
 

--- a/Utils/Colors/ColorManager.cs
+++ b/Utils/Colors/ColorManager.cs
@@ -1,0 +1,823 @@
+﻿using Levrum.Utils.Infra;
+
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+
+namespace Levrum.Utils.Colors
+{
+    public class ColorManager
+    {
+        /*      "Tutorial"
+         *      
+         *          Saving Colors
+         *      Create a dicionary of ColorableObjects with the name of the object as the key.
+         *      Each object will act as a link between any named object and the colors for that object.
+         *      
+         *      Create a dictionary for each category of object. For example, "Stations", "Regions", "Causes", etc.
+         *      That dictionary can be passed into SaveColorCSV() to save the initial dictionary.
+         *      Alternatively, AddCategory() and UpdateCategory() can be used to edit the dictionary one category at a time.
+         * 
+         *          Loading Colors
+         *      You can get the colors you want by simply passing in a list of the name of objects you want colors for.
+         *      Get_____ColorLookup() will return a dictionary with the keys as values and the colors as the values
+         *      GetCategory() will return the category of the colors you passed in.
+         *      LoadColorCSV() will load the full dictionary while LoadCategoryByLookup() and LoadCategoryByName() will return a single category
+         */
+
+        /// <summary>
+        /// This is the access point for actually accessing the custom colors. Just pass it a list of objects names you want colors for.
+        /// It will return a dictionary with those object names as the key and the cooresponding colorable object's color
+        /// </summary>
+        /// <param name="lookupValues"></param>
+        /// <returns>Dictionary<string, Color></returns>
+        public Dictionary<string, Color> GetFillColorLookup(List<string> lookupValues)
+        {
+            string fn = MethodBase.GetCurrentMethod().Name;
+            try
+            {
+                return BestMatchMethod(lookupValues, LoadColorCSV(), LoadManyToOneLookupDict());
+            }
+            catch (Exception exc)
+            {
+                Util.HandleExc(this, fn, exc);
+                return new Dictionary<string, Color>();
+            }
+        }
+
+        public Dictionary<string, Color> GetBorderColorLookup(List<string> lookupValues)
+        {
+            string fn = MethodBase.GetCurrentMethod().Name;
+            try
+            {
+                return BestMatchMethod(lookupValues, LoadColorCSV(), LoadManyToOneLookupDict());
+            }
+            catch (Exception exc)
+            {
+                Util.HandleExc(this, fn, exc);
+                return new Dictionary<string, Color>();
+            }
+        }
+
+        private Dictionary<string, Color> BestMatchMethod(List<string> lookupValues, Dictionary<string, Dictionary<string, ColorableObject>> customColorDict, Dictionary<string, string> manyToOneLookup = null, bool getBorderColor = false)
+        {
+            //This finds the best matching category based on how well the lookupValues match up with each custom color category
+            //It will work for any list of strings that match up with the names of the ColorableObjects
+            //What is returned is a dictionary with the lookup value as the key and the cooresponding color as the value
+
+            //manyToOneLookup must have values that match the names of items in the colorableColorDict. For example, C3S results as the key and the model as the value
+            if (customColorDict == null || customColorDict.Count == 0)
+            {
+                return new Dictionary<string, Color>();
+            }
+
+            customColorDict["Many to One Custom Key"] = new Dictionary<string, ColorableObject>();
+            if (manyToOneLookup != null)
+            {
+                foreach (string manyToOneLookupKey in manyToOneLookup.Keys)
+                {
+                    customColorDict["Many to One Custom Key"][manyToOneLookupKey] = new ColorableObject(manyToOneLookupKey, "Unknown");
+                }
+            }
+
+            Dictionary<string, Color> colorLookupDict = new Dictionary<string, Color>();
+            float bestMatchPercent = 0;
+            int bestFuzzyMatchCount = 0;
+            int bestExactMatchCount = 0;
+            string bestMatchCat = "";
+
+            foreach (var cat in customColorDict)
+            {
+                int exactMatchCount = 0;
+                int fuzzyMatchCount = 0;
+                foreach (ColorableObject obj in cat.Value.Values)
+                {
+                    if (lookupValues.Contains(obj.Name))
+                    {
+                        fuzzyMatchCount++;
+                    }
+                    foreach (string lookupValue in lookupValues)
+                    {
+                        if (lookupValue == obj.Name)
+                        {
+                            exactMatchCount++;
+                        }
+                    }
+                }
+
+                if (exactMatchCount > bestExactMatchCount)
+                {
+                    //The best category to choose is where the most fields match exactly what we were given
+                    bestExactMatchCount = exactMatchCount;
+                    bestFuzzyMatchCount = fuzzyMatchCount;
+                    bestMatchPercent = (exactMatchCount + fuzzyMatchCount) / (cat.Value.Count / 2);
+                    bestMatchCat = cat.Key;
+                }
+                else if (exactMatchCount == bestExactMatchCount && fuzzyMatchCount > bestFuzzyMatchCount)
+                {
+                    //If there is an exact match tie, go with the one with more fuzzy matches
+                    bestFuzzyMatchCount = fuzzyMatchCount;
+                    bestMatchPercent = (exactMatchCount + fuzzyMatchCount) / (cat.Value.Count / 2);
+                    bestMatchCat = cat.Key;
+                }
+                else if (exactMatchCount == bestExactMatchCount && fuzzyMatchCount == bestFuzzyMatchCount &&
+                    (Convert.ToDouble(fuzzyMatchCount) + Convert.ToDouble(exactMatchCount))
+                    / (Convert.ToDouble(cat.Value.Count) * 2) > bestMatchPercent)
+                {
+                    //In the case of a tie with both match types, go with the one with the highest % of matches
+                    bestMatchPercent = fuzzyMatchCount / cat.Value.Count;
+                    bestMatchCat = cat.Key;
+                }
+            }
+
+            if (bestMatchCat != "")
+            {
+                if (bestMatchCat != "Many to One Custom Key")
+                {
+                    foreach (string lookupValue in lookupValues)
+                    {
+                        if (customColorDict[bestMatchCat].ContainsKey(lookupValue))
+                        {
+                            ColorableObject obj = customColorDict[bestMatchCat][lookupValue];
+                            if (!getBorderColor)
+                            {
+                                if (obj.FillColor != Color.Empty)
+                                {
+                                    colorLookupDict[lookupValue] = customColorDict[bestMatchCat][lookupValue].FillColor;
+                                }
+                                else if (!string.IsNullOrEmpty(obj.Parent) && customColorDict.ContainsKey(obj.ParentType) &&
+                                    customColorDict[obj.ParentType].ContainsKey(obj.Parent) && customColorDict[obj.ParentType][obj.Parent].FillColor != Color.Empty)
+                                {
+                                    //Wow that is a mess of an if....lol
+                                    //If it didn't have a color itself but it's parent did, use the parent's color...
+                                    colorLookupDict[lookupValue] = customColorDict[obj.ParentType][obj.Parent].FillColor;
+                                }
+                            }
+                            else
+                            {
+                                if (obj.BorderColor != Color.Empty)
+                                {
+                                    colorLookupDict[lookupValue] = customColorDict[bestMatchCat][lookupValue].BorderColor;
+                                }
+                                else if (!string.IsNullOrEmpty(obj.Parent) && customColorDict.ContainsKey(obj.ParentType) &&
+                                    customColorDict[obj.ParentType].ContainsKey(obj.Parent) && customColorDict[obj.ParentType][obj.Parent].BorderColor != Color.Empty)
+                                {
+                                    //Wow that is a mess of an if....lol
+                                    //If it didn't have a color itself but it's parent did, use the parent's color...
+                                    colorLookupDict[lookupValue] = customColorDict[obj.ParentType][obj.Parent].BorderColor;
+                                }
+                            }
+
+                        }
+                    }
+                }
+                else
+                {
+                    //Getting recursive up in here!
+                    Dictionary<string, Color> tempColorLookupDict = BestMatchMethod(manyToOneLookup.Values.ToList(), customColorDict);
+                    foreach (var lookupValue in lookupValues)
+                    {
+                        if (manyToOneLookup.ContainsKey(lookupValue) && tempColorLookupDict.ContainsKey(manyToOneLookup[lookupValue]))
+                        {
+                            //A bit confusing but many to one uses the values we were passed to get the corresponding colorable object
+                            colorLookupDict[lookupValue] = tempColorLookupDict[manyToOneLookup[lookupValue]];
+                        }
+                    }
+                }
+            }
+
+            return colorLookupDict;
+        }
+
+        public string GetColorCategory(List<string> lookupValues)
+        {
+            string fn = MethodBase.GetCurrentMethod().Name;
+            try
+            {
+                return BestMatchMethod_ReturnCategory(lookupValues, LoadColorCSV(), LoadManyToOneLookupDict());
+            }
+            catch (Exception exc)
+            {
+                Util.HandleExc(this, fn, exc);
+                return null;
+            }
+
+
+        }
+
+        private string BestMatchMethod_ReturnCategory(List<string> lookupValues, Dictionary<string, Dictionary<string, ColorableObject>> customColorDict, Dictionary<string, string> manyToOneLookup = null)
+        {
+            //This is a copy of the best match method but it will return the category instead of the color lookup...
+            if (customColorDict == null || customColorDict.Count == 0)
+            {
+                return null;
+            }
+
+            customColorDict["Many to One Custom Key"] = new Dictionary<string, ColorableObject>();
+            if (manyToOneLookup != null)
+            {
+                foreach (string manyToOneLookupKey in manyToOneLookup.Keys)
+                {
+                    customColorDict["Many to One Custom Key"][manyToOneLookupKey] = new ColorableObject(manyToOneLookupKey, "Unknown");
+                }
+            }
+
+            float bestMatchPercent = 0;
+            int bestFuzzyMatchCount = 0;
+            int bestExactMatchCount = 0;
+            string bestMatchCat = "";
+
+            foreach (var cat in customColorDict)
+            {
+                int exactMatchCount = 0;
+                int fuzzyMatchCount = 0;
+                foreach (ColorableObject obj in cat.Value.Values)
+                {
+                    if (lookupValues.Contains(obj.Name))
+                    {
+                        fuzzyMatchCount++;
+                    }
+                    foreach (string lookupValue in lookupValues)
+                    {
+                        if (lookupValue == obj.Name)
+                        {
+                            exactMatchCount++;
+                        }
+                    }
+                }
+
+                if (exactMatchCount > bestExactMatchCount)
+                {
+                    //The best category to choose is where the most fields match exactly what we were given
+                    bestExactMatchCount = exactMatchCount;
+                    bestFuzzyMatchCount = fuzzyMatchCount;
+                    bestMatchPercent = (exactMatchCount + fuzzyMatchCount) / (cat.Value.Count / 2);
+                    bestMatchCat = cat.Key;
+                }
+                else if (exactMatchCount == bestExactMatchCount && fuzzyMatchCount > bestFuzzyMatchCount)
+                {
+                    //If there is an exact match tie, go with the one with more fuzzy matches
+                    bestFuzzyMatchCount = fuzzyMatchCount;
+                    bestMatchPercent = (exactMatchCount + fuzzyMatchCount) / (cat.Value.Count / 2);
+                    bestMatchCat = cat.Key;
+                }
+                else if (exactMatchCount == bestExactMatchCount && fuzzyMatchCount == bestFuzzyMatchCount &&
+                    (Convert.ToDouble(fuzzyMatchCount) + Convert.ToDouble(exactMatchCount))
+                    / (Convert.ToDouble(cat.Value.Count) * 2) > bestMatchPercent)
+                {
+                    //In the case of a tie with both match types, go with the one with the highest % of matches
+                    bestMatchPercent = fuzzyMatchCount / cat.Value.Count;
+                    bestMatchCat = cat.Key;
+                }
+            }
+
+            if (bestMatchCat != "")
+            {
+                if (bestMatchCat != "Many to One Custom Key")
+                {
+                    return bestMatchCat;
+                }
+                else
+                {
+                    //Getting recursive up in here!
+                    return BestMatchMethod_ReturnCategory(manyToOneLookup.Values.ToList(), customColorDict);
+                }
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// Saving and loading of the custom color dictionaries.
+        /// The 1st level dictionary's key is a category(e.g. "Models", "Causes", etc.)
+        /// The second level key is the colorable object's name(e.g. "EMS", "Fire", etc.)
+        /// </summary>
+        /// <param name="colorableObjects"></param>
+        public bool SaveColorCSV(Dictionary<string, Dictionary<string, ColorableObject>> colorableObjects)
+        {
+            string fn = MethodBase.GetCurrentMethod().Name;
+            try
+            {
+                Directory.CreateDirectory(AppSettings.ColorDir);
+
+                colorableObjects = SortObjectsProperly(colorableObjects);
+
+                string saveDestination = AppSettings.ColorDir + "CustomColors.csv";
+                if (File.Exists(saveDestination + "CustomColors.csv"))
+                {
+                    //Prompt user to see if they want to overwrite existing file
+                }
+
+                using (StreamWriter sw = new StreamWriter(saveDestination))
+                {
+                    sw.WriteLine("\"Type\",\"Name\",\"TypeGrouping\",\"Parent\",\"ParentType\",\"A\",\"R\",\"G\",\"B\",\"A2\",\"R2\",\"G2\",\"B2\"");
+                    foreach (var objCategory in colorableObjects.Values)
+                    {
+                        foreach (ColorableObject obj in objCategory.Values)
+                        {
+                            if (obj.FillColor != Color.Empty)
+                            {
+                                if (obj.BorderColor != Color.Empty)
+                                {
+                                    //Write all colors
+                                    sw.WriteLine(string.Concat("\"", obj.Type, "\",\"", obj.Name, "\",\"", obj.TypeGrouping, "\",\"", obj.Parent, "\",\"", obj.ParentType, "\",\"",
+                                        obj.FillColor.A, "\",\"", obj.FillColor.R, "\",\"", obj.FillColor.G, "\",\"", obj.FillColor.B, "\",\"",
+                                        obj.BorderColor.A, "\",\"", obj.BorderColor.R, "\",\"", obj.BorderColor.G, "\",\"", obj.BorderColor.B, "\""));
+                                }
+                                else
+                                {
+                                    //Write fill color but no border
+                                    sw.WriteLine(string.Concat("\"", obj.Type, "\",\"", obj.Name, "\",\"", obj.TypeGrouping, "\",\"", obj.Parent, "\",\"", obj.ParentType, "\",\"",
+                                        obj.FillColor.A, "\",\"", obj.FillColor.R, "\",\"", obj.FillColor.G, "\",\"", obj.FillColor.B, "\",\"",
+                                        "\",\"\",\"\",\"\",\"\""));
+                                }
+                            }
+                            else
+                            {
+                                if (obj.BorderColor != Color.Empty)
+                                {
+                                    //Write border color but no fill
+                                    sw.WriteLine(string.Concat("\"", obj.Type, "\",\"", obj.Name, "\",\"", obj.TypeGrouping, "\",\"", obj.Parent, "\",\"", obj.ParentType, "\",\"",
+                                        "\",\"\",\"\",\"\",\"",
+                                        obj.BorderColor.A, "\",\"", obj.BorderColor.R, "\",\"", obj.BorderColor.G, "\",\"", obj.BorderColor.B, "\""));
+                                }
+                                else
+                                {
+                                    //Write no color
+                                    sw.WriteLine(string.Concat("\"", obj.Type, "\",\"", obj.Name, "\",\"", obj.TypeGrouping, "\",\"", obj.Parent, "\",\"", obj.ParentType, "\",\"",
+                                        "\",\"\",\"\",\"\",\"",
+                                        "\",\"\",\"\",\"\",\"\""));
+                                }
+                            }
+                        }
+                    }
+
+                    sw.Close();
+                }
+                return true;
+            }
+            catch (Exception exc)
+            {
+                Util.HandleExc(this, fn, exc);
+                return false;
+            }
+        }
+
+        public bool UpdateCategory(Dictionary<string, ColorableObject> colorableCategory)
+        {
+            try
+            {
+                if (colorableCategory.Count == 0)
+                {
+                    return false;
+                }
+
+                string category = GetColorCategory(colorableCategory.Keys.ToList());
+                if (string.IsNullOrEmpty(category))
+                {
+                    return false;
+                }
+                Dictionary<string, Dictionary<string, ColorableObject>> colorDictionary = LoadColorCSV();
+
+                foreach (var obj in colorDictionary[category].ToArray())
+                {
+                    if (colorableCategory.ContainsKey(obj.Key) && colorDictionary[category][obj.Key].FillColor != colorableCategory[obj.Key].FillColor
+                        && colorableCategory[obj.Key].FillColor != Color.Empty)
+                    {
+                        //If the fill color changed, add it
+                        colorDictionary[category][obj.Key].FillColor = colorableCategory[obj.Key].FillColor;
+                    }
+
+                    if (colorableCategory.ContainsKey(obj.Key) && colorDictionary[category][obj.Key].BorderColor != colorableCategory[obj.Key].BorderColor
+                        && colorableCategory[obj.Key].BorderColor != Color.Empty)
+                    {
+                        colorDictionary[category][obj.Key].BorderColor = colorableCategory[obj.Key].BorderColor;
+                    }
+
+                    colorableCategory.Remove(obj.Key);
+                }
+
+                foreach (var unmatchedObj in colorableCategory)
+                {
+                    if (!colorDictionary.ContainsKey(unmatchedObj.Key))
+                    {
+                        //No existing object in the dictionary. Should we add a new one?
+                        //Probably...
+
+                    }
+                }
+
+                SaveColorCSV(colorDictionary);
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+
+        }
+
+        public void AddCategory(string category, Dictionary<string, ColorableObject> colorableCategory)
+        {
+            //This will either add or overwrite any category with the new values.
+            try
+            {
+                Dictionary<string, Dictionary<string, ColorableObject>> colorDictionary = LoadColorCSV();
+                colorDictionary[category] = colorableCategory;
+                SaveColorCSV(colorDictionary);
+            }
+            catch
+            {
+
+            }
+        }
+
+        public Dictionary<string, ColorableObject> LoadCategoryByLookup(List<string> lookupValues)
+        {
+            try
+            {
+                if (lookupValues.Count > 0)
+                {
+                    string category = GetColorCategory(lookupValues);
+                    if (string.IsNullOrEmpty(category))
+                    {
+                        return new Dictionary<string, ColorableObject>();
+                    }
+
+                    Dictionary<string, Dictionary<string, ColorableObject>> colorDictionary = LoadColorCSV();
+
+                    if (colorDictionary.ContainsKey(category))
+                    {
+                        return colorDictionary[category];
+                    }
+                    else
+                    {
+                        return new Dictionary<string, ColorableObject>();
+                    }
+                }
+                else
+                {
+                    return new Dictionary<string, ColorableObject>();
+                }
+            }
+            catch
+            {
+                return new Dictionary<string, ColorableObject>();
+            }
+        }
+
+        public Dictionary<string, ColorableObject> LoadCategoryByName(string category)
+        {
+            try
+            {
+                Dictionary<string, Dictionary<string, ColorableObject>> colorDictionary = LoadColorCSV();
+                if (colorDictionary.ContainsKey(category))
+                {
+                    return colorDictionary[category];
+                }
+                else
+                {
+                    return new Dictionary<string, ColorableObject>();
+                }
+            }
+            catch
+            {
+                return new Dictionary<string, ColorableObject>();
+            }
+        }
+
+        public Dictionary<string, Dictionary<string, ColorableObject>> LoadColorCSV()
+        {
+            string customColorSource = AppSettings.ColorDir + "CustomColors.csv";
+            string fn = MethodBase.GetCurrentMethod().Name;
+            try
+            {
+                Dictionary<string, Dictionary<string, ColorableObject>> colorableObjects = new Dictionary<string, Dictionary<string, ColorableObject>>();
+                if (File.Exists(customColorSource))
+                {
+                    using (StreamReader sr = new StreamReader(customColorSource))
+                    {
+                        string line = sr.ReadLine(); //header
+                        if (line != "\"Type\",\"Name\",\"TypeGrouping\",\"Parent\",\"ParentType\",\"A\",\"R\",\"G\",\"B\",\"A2\",\"R2\",\"G2\",\"B2\"")
+                        {
+                            //Header isn't right...stopping now to prevent problems
+                            return colorableObjects;
+                        }
+                        string[] header = line.Split(',');
+
+                        int fillAlphaIndex = 0;
+                        int borderAlphaIndex = 0;
+                        int i = 0;
+                        foreach (string s in header)
+                        {
+                            if (s == "\"A\"")
+                            {
+                                fillAlphaIndex = i;
+                            }
+                            if (s == "\"A2\"")
+                            {
+                                borderAlphaIndex = i;
+                            }
+                            i++;
+                        }
+
+                        line = sr.ReadLine();
+                        while (line != null)
+                        {
+                            string[] values = line.Split(',');
+                            List<string> valueCorrection = new List<string>();
+                            string appendedValue = "";
+                            foreach (string value in values)
+                            {
+                                if (value.Length < 2)
+                                {
+                                    if (!string.IsNullOrEmpty(value) && value != "\"")
+                                    {
+                                        appendedValue += ",";
+                                        appendedValue += value;
+                                        continue;
+                                    }
+                                    else if (!string.IsNullOrEmpty(appendedValue) && value == "\"")
+                                    {
+                                        appendedValue += ",";
+                                        valueCorrection.Add(appendedValue);
+                                        appendedValue = "";
+                                        continue;
+                                    }
+                                    else
+                                    {
+                                        //I believe this shouldn't get hit but if the value is null, don't worry about it...
+                                        continue;
+                                    }
+                                }
+
+                                if (value.First() == '"' && value.Last() == '"')
+                                {
+                                    valueCorrection.Add(value.Substring(1, value.Length - 2));
+                                }
+                                else if (value.First() == '"')
+                                {
+                                    appendedValue = value.Substring(1, value.Length - 1);
+                                }
+                                else if (value.Last() == '"')
+                                {
+                                    appendedValue += ",";
+                                    appendedValue += value.Substring(0, value.Length - 1);
+                                    valueCorrection.Add(appendedValue);
+                                    appendedValue = "";
+                                }
+                                else
+                                {
+                                    appendedValue += ",";
+                                    appendedValue += value;
+                                }
+                            }
+
+                            values = valueCorrection.ToArray();
+
+                            ColorableObject obj;
+                            if (values[fillAlphaIndex] != "")
+                            {
+                                //It has a color
+                                obj = new ColorableObject(values[1], values[0], values[2], values[3], values[4],
+                                    Color.FromArgb(Convert.ToInt32(values[fillAlphaIndex]),
+                                    Convert.ToInt32(values[fillAlphaIndex + 1]),
+                                    Convert.ToInt32(values[fillAlphaIndex + 2]),
+                                    Convert.ToInt32(values[fillAlphaIndex + 3])));
+                            }
+                            else
+                            {
+                                //It doesn't have a color
+                                obj = new ColorableObject(values[1], values[0], values[2], values[3], values[4]);
+                            }
+
+                            if (values[borderAlphaIndex] != "")
+                            {
+                                obj.BorderColor = Color.FromArgb(Convert.ToInt32(values[borderAlphaIndex]),
+                                    Convert.ToInt32(values[borderAlphaIndex + 1]),
+                                    Convert.ToInt32(values[borderAlphaIndex + 2]),
+                                    Convert.ToInt32(values[borderAlphaIndex + 3]));
+                            }
+
+                            if (colorableObjects.ContainsKey(obj.Type))
+                            {
+                                //Category has been created already
+                                colorableObjects[obj.Type][obj.Name] = obj;
+                            }
+                            else
+                            {
+                                //Category needs to be created
+                                colorableObjects[obj.Type] = new Dictionary<string, ColorableObject>();
+                                colorableObjects[obj.Type][obj.Name] = obj;
+                            }
+                            line = sr.ReadLine();
+                        }
+                        sr.Close();
+                    }
+                }
+
+                return colorableObjects;
+            }
+            catch (Exception exc)
+            {
+                Util.HandleExc(this, fn, exc);
+                return null;
+            }
+        }
+
+        private Dictionary<string, Dictionary<string, ColorableObject>> SortObjectsProperly(Dictionary<string, Dictionary<string, ColorableObject>> colorableObjects)
+        {
+            string fn = MethodBase.GetCurrentMethod().Name;
+            try
+            {
+                //12 coming before 2 is bugging me when trying to color objects.
+                Dictionary<string, Dictionary<string, ColorableObject>> fixedSort = new Dictionary<string, Dictionary<string, ColorableObject>>();
+
+                foreach (var colorableCategory in colorableObjects)
+                {
+                    Dictionary<string, SortingObject> numericSortCorrecter = new Dictionary<string, SortingObject>();
+                    foreach (string name in colorableCategory.Value.Keys)
+                    {
+                        int endNumber = 0;
+                        int lastSuccessfulNumber = 0;
+                        string endNumberString = "";
+                        string beginningText = name;
+                        while (beginningText.Length > 0 && int.TryParse(endNumberString = beginningText.Last() + endNumberString, out endNumber) && beginningText.Last() != ' ')
+                        {
+                            beginningText = name.Substring(0, beginningText.Length - 1);
+                            lastSuccessfulNumber = endNumber;
+                        }
+                        SortingObject obj = new SortingObject(beginningText, lastSuccessfulNumber);
+                        obj.TypeGrouping = colorableCategory.Value[name].TypeGrouping;
+                        numericSortCorrecter[name] = obj;
+                    }
+
+                    IOrderedEnumerable<KeyValuePair<string, SortingObject>> sortedCollection = numericSortCorrecter
+                        .OrderBy(x => x.Value.EndingNumber)
+                        .OrderBy(x => x.Value.BeginningText)
+                        .OrderBy(x => x.Value.TypeGrouping);
+
+                    Dictionary<string, ColorableObject> resortedDict = new Dictionary<string, ColorableObject>();
+                    foreach (var resortedString in sortedCollection)
+                    {
+                        if (colorableCategory.Value.ContainsKey(resortedString.Key))
+                        {
+                            resortedDict[resortedString.Key] = colorableCategory.Value[resortedString.Key];
+                        }
+                        else
+                        {
+                            //This really should never be hit but I'm leaving a breadcrumb for now just in case.
+                            Console.WriteLine("Get mad @Sean! ColorManager.SortObjectsProperly missing values...");
+                        }
+                    }
+                    fixedSort[colorableCategory.Key] = resortedDict;
+                }
+                return fixedSort;
+            }
+            catch (Exception exc)
+            {
+                Util.HandleExc(this, fn, exc);
+                return colorableObjects;
+            }
+        }
+
+        /// <summary>
+        /// The ManyToOneLookupDict is used to color non-colorable objects with a seperate colorable object
+        /// The use case is basically when an object gets created and destroyed frequently
+        /// I use it for results-models. Results(many) are colored with their model(one)
+        /// </summary>
+        /// <param name="manyToOneLookupDict"></param>
+        public void SaveManyToOneLookupDict(Dictionary<string, string> manyToOneLookupDict)
+        {
+            try
+            {
+                Directory.CreateDirectory(AppSettings.ColorDir);
+
+                using (StreamWriter sw = new StreamWriter(AppSettings.ColorDir + "ManyToOneLookup.csv"))
+                {
+                    sw.WriteLine("\"LookupValue\",\"LookupKey\"");
+
+                    foreach (KeyValuePair<string, string> resultModel in manyToOneLookupDict)
+                    {
+                        sw.WriteLine(string.Concat("\"", resultModel.Key, "\",\"", resultModel.Value, "\""));
+                    }
+                    sw.Close();
+                }
+            }
+            catch
+            {
+
+            }
+        }
+
+        public Dictionary<string, string> LoadManyToOneLookupDict()
+        {
+            try
+            {
+                Dictionary<string, string> manyToOneLookupDict = new Dictionary<string, string>();
+
+                string manyToOneLookupFile = AppSettings.ColorDir + "ManyToOneLookup.csv";
+
+                if (File.Exists(manyToOneLookupFile))
+                {
+                    using (StreamReader sr = new StreamReader(manyToOneLookupFile))
+                    {
+                        string line = sr.ReadLine(); //header
+
+                        line = sr.ReadLine();
+                        line = sr.ReadLine();
+                        while (line != null)
+                        {
+                            string[] values = line.Split(',');
+                            List<string> valueCorrection = new List<string>();
+
+                            string appendedValue = "";
+                            foreach (string value in values)
+                            {
+                                if (value.Length < 2)
+                                {
+                                    if (!string.IsNullOrEmpty(value) && value != "\"")
+                                    {
+                                        appendedValue += ",";
+                                        appendedValue += value;
+                                        continue;
+                                    }
+                                    else if (!string.IsNullOrEmpty(appendedValue) && value == "\"")
+                                    {
+                                        appendedValue += ",";
+                                        valueCorrection.Add(appendedValue);
+                                        appendedValue = "";
+                                        continue;
+                                    }
+                                    else
+                                    {
+                                        //I believe this shouldn't get hit but if the value is null, don't worry about it...
+                                        continue;
+                                    }
+                                }
+
+                                if (value.First() == '"' && value.Last() == '"')
+                                {
+                                    valueCorrection.Add(value.Substring(1, value.Length - 2));
+                                }
+                                else if (value.First() == '"')
+                                {
+                                    appendedValue = value.Substring(1, value.Length - 1);
+                                }
+                                else if (value.Last() == '"')
+                                {
+                                    appendedValue += ",";
+                                    appendedValue += value.Substring(0, value.Length - 1);
+                                    valueCorrection.Add(appendedValue);
+                                    appendedValue = "";
+                                }
+                                else
+                                {
+                                    appendedValue += ",";
+                                    appendedValue += value;
+                                }
+                            }
+
+                            values = valueCorrection.ToArray();
+
+                            manyToOneLookupDict[values[0]] = values[1];
+                            line = sr.ReadLine();
+                        }
+
+                        while (line != null)
+                        {
+                            string[] values = line.Split(',');
+
+                            manyToOneLookupDict[values[0]] = values[1];
+
+                            line = sr.ReadLine();
+                        }
+                        sr.Close();
+                    }
+                }
+
+                return manyToOneLookupDict;
+            }
+            catch
+            {
+                return null;
+            }
+        }
+    }
+    class SortingObject
+    {
+        public string TypeGrouping { get; set; }
+        public string BeginningText { get; set; }
+        public int EndingNumber { get; set; }
+
+        public SortingObject(string beginningText = "_", int endingNumber = -1)
+        {
+            //The defaults are there because if the object being sorted doesn't have either, it should show above objects that do.
+            //For example, 123 should be above a123. abc should show above abc1.
+            BeginningText = beginningText;
+            EndingNumber = endingNumber;
+        }
+    }
+}

--- a/Utils/Colors/ColorableObject.cs
+++ b/Utils/Colors/ColorableObject.cs
@@ -1,0 +1,64 @@
+﻿using System.Drawing;
+
+namespace Levrum.Utils.Colors
+{
+    public class ColorableObject
+    {
+        /*      Overview:
+         *      
+         *          Each ColorableObject acts as a link between a named object and the colors you want to use for it.
+         *          They go into Dictionaries used by the ColorManager
+         *          
+         *          Fields:
+         *          Name - Uhhh.... does your object have a name?
+         *          Type - The category of object that the dictionaries ColorManager is using.
+         *          TypeGrouping - The pretty pring version of the type. I mostly use if for UI elements.
+         *          Parent - The ColorableObject which this will defualt the color to if it doesn't have its own.
+         *          ParentType - The type/category of the parent.
+         *          FillColor - The back color. AKA main color.
+         *          BorderColor - The accent color usually used around edges.
+         */
+
+        public string Name { get; set; } //For example, Stucture Fire
+        public string Type { get; set; }//For example, Cause
+        public string TypeGrouping { get; set; } //Optional. For example, Level 2 Cause
+        public string Parent { get; set; } //Optional. For example, Fire
+        public string ParentType { get; set; } //Optional. For example, Cause. Does not need to match parent type. For example, E2's parent could be Unit Role
+        public Color FillColor { get; set; } //The main object color
+        public Color BorderColor { get; set; } //The secondary color that shows around the edge
+        public ColorableObject(string name, string type, string typeGrouping = "", string parent = "", string parentType = "", Color? fillColor = null, Color? borderColor = null)
+        {
+            Name = name;
+            Type = type;
+            TypeGrouping = typeGrouping;
+            Parent = parent;
+            ParentType = parentType;
+            FillColor = fillColor.GetValueOrDefault(Color.Empty);
+            BorderColor = borderColor.GetValueOrDefault(Color.Empty);
+        }
+
+        public void RemoveColor()
+        {
+            FillColor = Color.Empty;
+            BorderColor = Color.Empty;
+        }
+
+        public bool HasFillColor()
+        {
+            if (FillColor != Color.Empty)
+            {
+                return true;
+            }
+            return false;
+        }
+
+        public bool HasBorderColor()
+        {
+            if (BorderColor != Color.Empty)
+            {
+                return true;
+            }
+            return false;
+        }
+    }
+}

--- a/Utils/Colors/Gradients.cs
+++ b/Utils/Colors/Gradients.cs
@@ -1,0 +1,455 @@
+﻿using Levrum.Utils.Infra;
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.IO;
+
+namespace Levrum.Utils.Colors
+{
+    public class Gradients
+    {
+        public List<Color> CreateTwoColorGradient(Color low, Color high, int numberOfIntervals = 100)
+        {
+            //This was adapted from C3mGMapControl.cs
+            //It will take in 2 colors and return a gradient with the chosen number of interval steps
+            try
+            {
+                List<Color> gradientColors = new List<Color>();
+
+                double first_interval_A = Convert.ToDouble(high.A - low.A) / (numberOfIntervals - 1);
+                double first_interval_R = Convert.ToDouble(high.R - low.R) / (numberOfIntervals - 1);
+                double first_interval_G = Convert.ToDouble(high.G - low.G) / (numberOfIntervals - 1);
+                double first_interval_B = Convert.ToDouble(high.B - low.B) / (numberOfIntervals - 1);
+
+                double current_A = low.A;
+                double current_R = low.R;
+                double current_G = low.G;
+                double current_B = low.B;
+                Color col;
+                for (int i = 0; i < numberOfIntervals - 1; i++)
+                {
+                    col = Color.FromArgb(Convert.ToInt32(current_A), Convert.ToInt32(current_R), Convert.ToInt32(current_G), Convert.ToInt32(current_B));
+                    gradientColors.Add(col);
+
+                    //increment.
+                    current_A += first_interval_A;
+                    current_R += first_interval_R;
+                    current_G += first_interval_G;
+                    current_B += first_interval_B;
+                }
+                col = Color.FromArgb(Convert.ToInt32(current_A), Convert.ToInt32(current_R), Convert.ToInt32(current_G), Convert.ToInt32(current_B));
+                gradientColors.Add(col);
+                return gradientColors;
+            }
+            catch
+            {
+                return new List<Color>();
+            }
+        }
+
+        public List<Color> CreateThreeColorGradient(Color low, Color mid, Color high, int numberOfIntervals = 100)
+        {
+            //This was taken from C3mGMapControl.cs and made more generic and with a couple of bug fixes
+            //It will take in 3 colors and return a gradient with the chosen number of interval steps
+
+            try
+            {
+                List<Color> gradientColors = new List<Color>();
+
+                double first_interval_A = Convert.ToDouble(mid.A - low.A) / ((numberOfIntervals / 2) - 1);
+                double first_interval_R = Convert.ToDouble(mid.R - low.R) / ((numberOfIntervals / 2) - 1);
+                double first_interval_G = Convert.ToDouble(mid.G - low.G) / ((numberOfIntervals / 2) - 1);
+                double first_interval_B = Convert.ToDouble(mid.B - low.B) / ((numberOfIntervals / 2) - 1);
+
+                double current_A = low.A;
+                double current_R = low.R;
+                double current_G = low.G;
+                double current_B = low.B;
+                Color col;
+                for (int i = 0; i < (numberOfIntervals / 2) - 1; i++)
+                {
+                    col = Color.FromArgb(Convert.ToInt32(current_A), Convert.ToInt32(current_R), Convert.ToInt32(current_G), Convert.ToInt32(current_B));
+                    gradientColors.Add(col);
+
+                    //increment.
+                    current_A += first_interval_A;
+                    current_R += first_interval_R;
+                    current_G += first_interval_G;
+                    current_B += first_interval_B;
+                }
+
+                col = Color.FromArgb(Convert.ToInt32(current_A), Convert.ToInt32(current_R), Convert.ToInt32(current_G), Convert.ToInt32(current_B));
+                gradientColors.Add(col);
+
+                double second_interval_A = Convert.ToDouble(high.A - mid.A) / ((numberOfIntervals / 2) - 1);
+                double second_interval_R = Convert.ToDouble(high.R - mid.R) / ((numberOfIntervals / 2) - 1);
+                double second_interval_G = Convert.ToDouble(high.G - mid.G) / ((numberOfIntervals / 2) - 1);
+                double second_interval_B = Convert.ToDouble(high.B - mid.B) / ((numberOfIntervals / 2) - 1);
+
+                current_A = mid.A;
+                current_R = mid.R;
+                current_G = mid.G;
+                current_B = mid.B;
+
+                for (int i = numberOfIntervals / 2; i < numberOfIntervals - 1; i++)
+                {
+                    col = Color.FromArgb(Convert.ToInt32(current_A), Convert.ToInt32(current_R), Convert.ToInt32(current_G), Convert.ToInt32(current_B));
+                    gradientColors.Add(col);
+
+                    //increment.
+                    current_A += second_interval_A;
+                    current_R += second_interval_R;
+                    current_G += second_interval_G;
+                    current_B += second_interval_B;
+                }
+                col = Color.FromArgb(Convert.ToInt32(current_A), Convert.ToInt32(current_R), Convert.ToInt32(current_G), Convert.ToInt32(current_B));
+                gradientColors.Add(col);
+                return gradientColors;
+            }
+            catch
+            {
+                return new List<Color>();
+            }
+        }
+
+        public List<Color> CreateNColorGradient(List<Color> colorsLowToHigh, int numberOfIntervals = 100)
+        {
+            try
+            {
+                List<Color> gradient = new List<Color>();
+
+                int intervalsPerColor = (numberOfIntervals / (colorsLowToHigh.Count - 1));
+                int leftovers = numberOfIntervals - (intervalsPerColor * (colorsLowToHigh.Count - 1));
+
+                for (int n = 0; n < colorsLowToHigh.Count - 1; n++)
+                {
+                    if (leftovers >= (colorsLowToHigh.Count - n) - 1)
+                    {
+                        if (leftovers == 1)
+                        {
+                            //I actually reintroduced a bug with the original gradients where the last color wasn't getting added to prevent
+                            //the middle gradient colors from getting added twice. This "fixes" it for the last color
+                            AddGradientSegment(gradient, colorsLowToHigh[n], colorsLowToHigh[n + 1], intervalsPerColor);
+                            gradient.Add(colorsLowToHigh[n + 1]);
+                        }
+                        else
+                        {
+                            AddGradientSegment(gradient, colorsLowToHigh[n], colorsLowToHigh[n + 1], intervalsPerColor + 1);
+                        }
+                        leftovers--;
+                    }
+                    else
+                    {
+                        AddGradientSegment(gradient, colorsLowToHigh[n], colorsLowToHigh[n + 1], intervalsPerColor);
+                    }
+                }
+
+                return gradient;
+            }
+            catch
+            {
+                return new List<Color>();
+            }
+        }
+
+        private void AddGradientSegment(List<Color> gradientSoFar, Color low, Color high, int numberOfIntervals)
+        {
+            double first_interval_A = Convert.ToDouble(high.A - low.A) / numberOfIntervals;
+            double first_interval_R = Convert.ToDouble(high.R - low.R) / numberOfIntervals;
+            double first_interval_G = Convert.ToDouble(high.G - low.G) / numberOfIntervals;
+            double first_interval_B = Convert.ToDouble(high.B - low.B) / numberOfIntervals;
+
+            double current_A = low.A;
+            double current_R = low.R;
+            double current_G = low.G;
+            double current_B = low.B;
+            Color col;
+            for (int i = 0; i < numberOfIntervals - 1; i++)
+            {
+                col = Color.FromArgb(Convert.ToInt32(current_A), Convert.ToInt32(current_R), Convert.ToInt32(current_G), Convert.ToInt32(current_B));
+                gradientSoFar.Add(col);
+                current_A += first_interval_A;
+                current_R += first_interval_R;
+                current_G += first_interval_G;
+                current_B += first_interval_B;
+            }
+            col = Color.FromArgb(Convert.ToInt32(current_A), Convert.ToInt32(current_R), Convert.ToInt32(current_G), Convert.ToInt32(current_B));
+            gradientSoFar.Add(col);
+        }
+
+        public Image CreateGradientImage(List<Color> gradient)
+        {
+            //Will create a horizontal image with dimensions of color count x 200 pixels
+            if (gradient.Count <= 0)
+            {
+                return null;
+            }
+
+            int width = gradient.Count;
+            int height = 200;
+
+            Image gradientImage = new Bitmap(width, height);
+
+            using (Graphics g = Graphics.FromImage(gradientImage))
+            {
+                for (int i = 0; i < width; i++)
+                {
+                    Color c = gradient[i];
+                    Rectangle line = new Rectangle(i, 0, 1, height);
+                    g.DrawRectangle(new Pen(c), line);
+                    g.FillRectangle(new SolidBrush(c), line);
+                }
+            }
+            return gradientImage;
+        }
+
+        public Image CreateGradientImage(List<Color> gradient, int width, int height, bool drawHorizontally = true)
+        {
+            //Allows custom dimensions for the gradient.
+            //If horizontal, having a width too small will lead to data loss. If vertical, the same is true for the height.
+            if (width <= 0 || height <= 0 || gradient.Count <= 0)
+            {
+                return null;
+            }
+
+            Image gradientImage = new Bitmap(width, height);
+
+            using (Graphics g = Graphics.FromImage(gradientImage))
+            {
+                if (drawHorizontally)
+                {
+                    for (int i = 0; i < width; i++)
+                    {
+                        int currentIndex = Convert.ToInt32((double)gradient.Count * ((double)i / (double)width));
+                        if (currentIndex > gradient.Count - 1)
+                        {
+                            currentIndex = gradient.Count - 1;
+                        }
+                        Color c = gradient[currentIndex];
+                        Rectangle line = new Rectangle(i, 0, 1, height);
+                        g.DrawRectangle(new Pen(c), line);
+                        g.FillRectangle(new SolidBrush(c), line);
+                    }
+                }
+                else
+                {
+                    for (int i = 0; i < height; i++)
+                    {
+                        Color c = gradient[i / height];
+                        Rectangle line = new Rectangle(0, i, width, 1);
+                        g.DrawRectangle(new Pen(c), line);
+                        g.FillRectangle(new SolidBrush(c), line);
+                    }
+                }
+            }
+            return gradientImage;
+        }
+
+        public List<Color> ExtractGradientFromImage(Image gradientImage)
+        {
+            List<Color> gradient = new List<Color>();
+            int width = gradientImage.Width;
+            int height = gradientImage.Height;
+
+            Bitmap gradientBitmap = new Bitmap(gradientImage);
+            Color previousColor = Color.Empty;
+            for (int x = 0; x < width; x++)
+            {
+                //Checks each pixel horizonally to get colors
+                Color pixel = gradientBitmap.GetPixel(x, 0);
+                if (previousColor != Color.Empty && pixel.Name != previousColor.Name)
+                {
+                    gradient.Add(pixel);
+                }
+                else
+                {
+                    gradient.Add(pixel);
+                }
+                previousColor = pixel;
+            }
+            if (gradient.Count > 1)
+            {
+                //If there was only one color, the gradient is going in another direction...
+                return gradient;
+            }
+
+            previousColor = Color.Empty;
+            for (int y = 0; y < height; y++)
+            {
+                Color pixel = gradientBitmap.GetPixel(0, y);
+                if (previousColor != Color.Empty && pixel.Name != previousColor.Name)
+                {
+                    gradient.Add(pixel);
+                }
+                else
+                {
+                    gradient.Add(pixel);
+                }
+                previousColor = pixel;
+            }
+
+            return gradient;
+        }
+
+        public bool SaveGradient(Image gradientImage, string fileName = "")
+        {
+            //If a file name is not provided, it will be named Gradient#.png where # is the first available int...
+            //The file name should only be the name. Don't include the folder...
+            try
+            {
+                string folder = AppSettings.ColorDir + "\\Gradients\\";
+                Directory.CreateDirectory(folder);
+
+                if (fileName == "")
+                {
+                    int fileNumber = 1;
+                    while (File.Exists(string.Concat(folder, "Gradient", fileNumber, ".png")))
+                    {
+                        fileNumber++;
+                    }
+                    gradientImage.Save(string.Concat(folder, "Gradient", fileNumber, ".png"), System.Drawing.Imaging.ImageFormat.Png);
+                }
+                else
+                {
+                    if (fileName.EndsWith(".png"))
+                    {
+                        if(File.Exists(string.Concat(folder, fileName)))
+                        {
+                            File.Delete(string.Concat(folder, fileName));
+                        }
+                        gradientImage.Save(string.Concat(folder, fileName), System.Drawing.Imaging.ImageFormat.Png);
+                    }
+                    else
+                    {
+                        if (File.Exists(string.Concat(folder, fileName, ".png")))
+                        {
+                            File.Delete(string.Concat(folder, fileName, ".png"));
+                        }
+                        gradientImage.Save(string.Concat(folder, fileName, ".png"), System.Drawing.Imaging.ImageFormat.Png);
+                    }
+                }
+                return true;
+            }
+            catch(Exception exc)
+            {
+                return false;
+            }
+        }
+
+        public bool SaveGradient(List<Color> gradient, string fileName = "", int customHeight = 100)
+        {
+            //If a file name is not provided, it will be named Gradient#.png where # is the first available int...
+            try
+            {
+                string folder = AppSettings.ColorDir + "\\Gradients\\";
+                Directory.CreateDirectory(folder);
+
+                if (fileName == "")
+                {
+                    int fileNumber = 1;
+                    while (File.Exists(string.Concat(folder, "Gradient", fileNumber, ".png")))
+                    {
+                        fileNumber++;
+                    }
+                    CreateGradientImage(gradient, gradient.Count - 1, customHeight).Save(string.Concat(folder, "Gradient", fileNumber, ".png"), System.Drawing.Imaging.ImageFormat.Png);
+                }
+                else
+                {
+                    if (fileName.EndsWith(".png"))
+                    {
+                        CreateGradientImage(gradient, gradient.Count - 1, customHeight).Save(string.Concat(folder, fileName), System.Drawing.Imaging.ImageFormat.Png);
+                    }
+                    else
+                    {
+                        CreateGradientImage(gradient, gradient.Count - 1, customHeight).Save(string.Concat(folder, fileName, ".png"), System.Drawing.Imaging.ImageFormat.Png);
+                    }
+                }
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        public bool SaveGradientList(List<Image> gradientList)
+        {
+            try
+            {
+                foreach (Image gradient in gradientList)
+                {
+                    SaveGradient(gradient);
+                }
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        public List<Color> LoadGradient(string fileName)
+        {
+            try
+            {
+                Image gradient = LoadGradientImage(fileName);
+
+                if (gradient != null)
+                {
+                    return ExtractGradientFromImage(LoadGradientImage(fileName));
+                }
+                else
+                {
+                    return new List<Color>();
+                }
+            }
+            catch
+            {
+                return new List<Color>();
+            }
+        }
+
+        public Image LoadGradientImage(string fileName)
+        {
+            try
+            {
+                string file = string.Concat(AppSettings.ColorDir, "\\Gradients\\", fileName);
+                if (File.Exists(file))
+                {
+                    return Image.FromFile(file);
+                }
+                else if (!file.EndsWith(".png"))
+                {
+                    file += ".png";
+                    if (File.Exists(file))
+                    {
+                        return Image.FromFile(file);
+                    }
+                }
+                return null;
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        public List<Image> LoadAllGradientImages()
+        {
+
+            try
+            {
+                List<Image> gradientImages = new List<Image>();
+                foreach (string file in Directory.EnumerateFiles(string.Concat(AppSettings.ColorDir, "\\Gradients\\"), "*.png"))
+                {
+                    gradientImages.Add(Image.FromFile(file));
+                }
+                return gradientImages;
+            }
+            catch
+            {
+                return new List<Image>();
+            }
+        }
+    }
+}

--- a/Utils/Infra/Miscellany.cs
+++ b/Utils/Infra/Miscellany.cs
@@ -854,7 +854,7 @@ namespace Levrum.Utils.Infra
 
         public static string ColorDir
         {
-            get { return (Util.SafeDir(Environment.SpecialFolder.ApplicationData + "\\Levrum\\CustomColors\\CustomColors\\")); }
+            get { return (Util.SafeDir(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + "\\Levrum\\CustomColors\\")); }
         }
 
         public static string LocalCfgDir

--- a/Utils/Infra/Miscellany.cs
+++ b/Utils/Infra/Miscellany.cs
@@ -852,6 +852,11 @@ namespace Levrum.Utils.Infra
             get { return (Util.SafeDir(RootDir + "config\\")); }
         }
 
+        public static string ColorDir
+        {
+            get { return (Util.SafeDir(Environment.SpecialFolder.ApplicationData + "\\Levrum\\CustomColors\\CustomColors\\")); }
+        }
+
         public static string LocalCfgDir
         {
             get { return (Util.SafeDir(LocalDir + "config\\")); }

--- a/Utils/Utils.csproj
+++ b/Utils/Utils.csproj
@@ -41,6 +41,7 @@
     <PackageReference Include="ProjNet" Version="2.0.0" />
     <PackageReference Include="RabbitMQ.Client" Version="5.1.2" />
     <PackageReference Include="ServiceWire" Version="5.3.4" />
+    <PackageReference Include="System.Drawing.Common" Version="5.0.2" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Adding the code that currently resides in CoeloUtils here. This also includes some gradient tests in the sandbox.

**Custom Colors**
Colorable objects tie a color to any named object. A colorable object has a name, type, and then optionally a parent to inherit from, a fill color, and a border color.
The ColorManager uses those objects to retrieve colors, save the dictionaries, and do a bunch of other stuff.

**Gradients**
This takes what was being used in the C3S results map, fixes a couple minor issues, and beefs it up all around. It can support unlimited color gradients as well as saving/loading the gradient images.